### PR TITLE
Range scanning/display features

### DIFF
--- a/release/scripts/addons/blensor/__init__.py
+++ b/release/scripts/addons/blensor/__init__.py
@@ -267,15 +267,15 @@ class OBJECT_PT_sensor(bpy.types.Panel):
             col = row.column()
             col.prop(obj, "add_noise_scan_mesh")
             row = layout.row()
-            row.prop(obj, "save_scan")
+            col = row.column()
+            col.prop(obj, "save_scan")
+            col = row.column()            
+            col.prop(obj,"local_coordinates")        
             row = layout.row()
             col = row.column()
             col.prop(obj, "scan_frame_start")
             col = row.column()
             col.prop(obj, "scan_frame_end")
-            row = layout.row()
-            row.prop(obj,"local_coordinates")        
-
 
             row = layout.row()
             row.operator("blensor.scan", "Single scan")        
@@ -651,7 +651,7 @@ def register():
     cType.add_noise_scan_mesh = bpy.props.BoolProperty( name = "Add noisy scan", default = False, description = "Should the noisy scan be added as an object" )
 
     cType.save_scan = bpy.props.BoolProperty( name = "Save to File", default = False, description = "Should the scan be saved to file" )
-    cType.local_coordinates = bpy.props.BoolProperty( name = "Sensor coordinates", default = True, description = "Should the points be in sensor coordinates" )
+    cType.local_coordinates = bpy.props.BoolProperty( name = "Sensor coordinates", default = True, description = "Should the points be saved sensor coordinates" )
 
 
     cType.scan_frame_start = bpy.props.IntProperty( name = "Start frame", default = 1, min = 0, description = "First frame to be scanned" )

--- a/release/scripts/addons/blensor/blendodyne.py
+++ b/release/scripts/addons/blensor/blendodyne.py
@@ -189,6 +189,10 @@ def scan_advanced(rotation_speed = 10.0, simulation_fps=24, angle_resolution = 0
         bpy.context.scene.objects.link(scan_mesh_object)
         blensor.show_in_frame(scan_mesh_object, bpy.context.scene.frame_current)
 
+        if world_transformation == Matrix():
+            scan_mesh_object.matrix_world = bpy.context.object.matrix_world
+
+
     if add_noisy_blender_mesh:
         noise_scan_mesh = bpy.data.meshes.new("noisy_scan_mesh")
         noise_scan_mesh.vertices.add(len(verts_noise))
@@ -197,6 +201,9 @@ def scan_advanced(rotation_speed = 10.0, simulation_fps=24, angle_resolution = 0
         noise_scan_mesh_object = bpy.data.objects.new("NoisyScan.{0}".format(bpy.context.scene.frame_current), noise_scan_mesh)
         bpy.context.scene.objects.link(noise_scan_mesh_object)
         blensor.show_in_frame(noise_scan_mesh_object, bpy.context.scene.frame_current)
+    
+        if world_transformation == Matrix():
+            noise_scan_mesh_object.matrix_world = bpy.context.object.matrix_world
 
     bpy.context.scene.update()
 


### PR DESCRIPTION
As a result of our email discussion, I've packaged the "new" features as this separate branch...
- Scans are added with their "frame number".. eg Scan.0, Scan.10 etc..
- Scans display only in the relevant frame (e.g. Scan.10 is visible only in frame 10)
- When doing a "scan range", scans will be added if that option is selected
- The delete operator deletes all scans (and "noisy scans") in the scene
- If "Sensor Coordinates" is selected:
  - File data is output in sensor frame
  - The matrix_world of the blender object is modified so it displays in the right place
- If "Sensor Coordinates" is not selected:
  - File data is output in world frame
  - Blender object is inserted at the origin
