### PR TITLE
Added ecx in clobber list of instruction cpuid.

### DIFF
--- a/source/blender/blenlib/intern/system.c
+++ b/source/blender/blenlib/intern/system.c
@@ -51,7 +51,8 @@ int BLI_cpu_support_sse2(void)
 	    "cpuid\n\t"
 	    "popl %%ebx\n\t"
 	    : "=d" (d)
-	    : "a" (1));
+	    : "a" (1)
+	    : "ecx");
 	return (d & 0x04000000) != 0;
 #elif (defined(_MSC_VER) && defined(_M_IX86))
 	/* also check cpuid for MSVC x86 */


### PR DESCRIPTION
From the x86_64 specification Vol. 2A 3-191, instruction cpuid will override register ecx when eax=01h, but in the source code of `source/blender/blenlib/intern/system.c`, ecx wasn't declared in clobber list. Declaring it will improve the runtime stability to some extent, for the reason that undeclared side effect may be miscompiled by compilers.
For example:
```
// cpuid.c
#include <stdio.h>

int BLI_cpu_support_sse2() {
  unsigned int d;
  __asm__(
      "pushl %%ebx\n\t"
      "cpuid\n\t"
      "popl %%ebx\n\t"
      : "=d"(d)
      : "a"(1));
  return (d & 0x04000000) != 0;
}

extern int func();

int main() {
  register int ecx asm("ecx") = func();
  if (BLI_cpu_support_sse2())
    printf("0:%08x\n", ecx);
  else
    printf("1:%08x\n", ecx);
  return 0;
}

// func.c
int func() { return 0x123456; }
```

Compile the above code with `gcc -O2 -m32 cpuid.c func.c -o cpuid` and run it will produce output `0:7ffafbff`, where the ecx is not the initial value assigned by `func()`;